### PR TITLE
Add "main" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 	"bin": {
 		"node-schematron": "./bin/schematron.js"
 	},
-	"main": "dist",
+	"main": "dist/index.js",
 	"scripts": {
 		"prepublish": "jest && npm run ts:build",
 		"test": "jest",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 	"bin": {
 		"node-schematron": "./bin/schematron.js"
 	},
+	"main": "dist",
 	"scripts": {
 		"prepublish": "jest && npm run ts:build",
 		"test": "jest",


### PR DESCRIPTION
Add a "main" entry to package.json, containing the path to the `dist` folder, so that `require('node-schematron')` knows where to find the module.